### PR TITLE
Onefile: Check output file exists before delete it. (#1176)

### DIFF
--- a/nuitka/freezer/Onefile.py
+++ b/nuitka/freezer/Onefile.py
@@ -195,7 +195,8 @@ Categories=Utility;"""
 
     if result != 0:
         # Useless now.
-        os.unlink(onefile_output_filename)
+        if os.path.exists(onefile_output_filename):
+            os.unlink(onefile_output_filename)
 
         stderr = getFileContents(stderr_filename, mode="rb")
 


### PR DESCRIPTION
* The `FileNotFoundError` will be raised when command execute failed. At that time, the it may or may not exist , so add a check before delete it.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/kayhayen/Nuitka/blob/master/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] All tests still pass. Check the developer manual about `Running the Tests`.
      There are Github Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
